### PR TITLE
Allow x-dynamic-key spec in fields

### DIFF
--- a/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
+++ b/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
@@ -343,6 +343,11 @@
         "explodeBy": {
           "title": "For internal usage only",
           "type": "string"
+        },
+        "x-dynamic-key": {
+          "title": "Dynamic Key Specification",
+          "description": "Use this if you need to expose array objects as an object using parts of the object as key. Gets transported into internal graviton schemas as a whole if specified.",
+          "$ref": "#/definition/xDynamicKey"
         }
       },
       "required": [
@@ -388,6 +393,31 @@
         "value"
       ],
       "additionalProperties": false
+    },
+    "xDynamicKey": {
+      "type": "object",
+      "properties": {
+        "document-id": {
+          "title": "Document ID",
+          "description": "Document type of document that shall has it's id used as object key.",
+          "type": "string"
+        },
+        "repository-method": {
+          "title": "Repository Method",
+          "description": "Method that is to be called on the document repository corresponding to the given document-id.",
+          "type": "string"
+        },
+        "ref-method": {
+          "title": "Ref Method",
+          "description": "What method to call on a document to find out what it's key should be when it needs to be exposed as object (ie. using additionalProperties) on it's parent. Graviton currently uses the id from the results of this call as key",
+          "type": "string"
+        }
+      },
+      "required": [
+        "document-id",
+        "repository-method",
+        "ref-method"
+      ]
     }
   }
 }


### PR DESCRIPTION
I'm using this to export arrays as objects using an object property to get at the value used as key.

Allows the fields introduced by https://github.com/libgraviton/graviton/pull/282 to be validated.