### PR TITLE
Allow collectionName in service

### DIFF
--- a/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
+++ b/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
@@ -167,6 +167,10 @@
           "items": {
             "$ref": "#/definitions/serviceFixture"
           }
+        },
+        "collectionName": {
+          "title": "Collection name",
+          "$ref": "#/definitions/collectionName"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
This allows us to override what collection a given service should take it's data from. Up until now the id field was used for the collection name. 

There are some cases where it makes more sense to use something different so this has been added here.