### PR TITLE
Fix "xDynamicKey" fragment path.

### DIFF
--- a/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
+++ b/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
@@ -347,7 +347,7 @@
         "x-dynamic-key": {
           "title": "Dynamic Key Specification",
           "description": "Use this if you need to expose array objects as an object using parts of the object as key. Gets transported into internal graviton schemas as a whole if specified.",
-          "$ref": "#/definition/xDynamicKey"
+          "$ref": "#/definitions/xDynamicKey"
         }
       },
       "required": [


### PR DESCRIPTION
Fix the error:
```
[JsonSchema\Exception\ResourceNotFoundException]                                                                                                                                                  
Fragment "/definition/xDynamicKey" not found in file:///sync/fork/vendor/graviton/json-schema/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json#/definition/xDynamicKey 
```