### PR TITLE
allow dot notation in localValueField relation field

### DIFF
--- a/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
+++ b/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
@@ -269,7 +269,7 @@
         },
         "localValueField": {
           "title": "Local value field",
-          "$ref": "#/definitions/fieldName"
+          "$ref": "#/definitions/fieldDefinitionName"
         },
         "foreignProperty": {
           "title": "Foreign relation field",


### PR DESCRIPTION
We did some adjustments on clients site for a load - after we tried to incorporate the new JSON definition into graviton, the schema validator complained about `relations.0.localValueField` containing dot notation.. ML3K has no problems with that, and IMHO it should be no problem with Graviton either. 

After we changed the schema, Graviton could easily generate the service and give the service data out correctly. So this change should be safe. What do you think @mrix?

