### PR TITLE
Feature/evo 5751 add text indexes

### DIFF
--- a/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
+++ b/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
@@ -236,8 +236,8 @@
           }
         },
         "textIndexes": {
-          "title": "Target Text Search Indexes, key: value for weight",
-          "type": "object",
+          "title": "Target Text Search Indexes, field and weight",
+          "type": "array",
           "items": {
             "$ref": "#/definitions/targetTextIndex"
           }
@@ -280,20 +280,20 @@
     "targetTextIndex": {
       "type": "object",
       "properties": {
-        "name": {
+        "field": {
           "title": "Weighted key name name to be solved in Search criteria",
           "type": "string"
         },
-        "value": {
+        "weight": {
           "title": "Importance criteria",
-          "type": "integer"
+          "type": "integer",
+          "minimum": 0
         }
       },
       "required": [
-        "name",
-        "value"
-      ],
-      "additionalProperties": false
+        "field",
+        "weight"
+      ]
     },
     "targetRelation": {
       "type": "object",

--- a/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
+++ b/src/Graviton/JsonSchemaBundle/Resources/schema/loadconfig/v1.0/schema.json
@@ -235,6 +235,13 @@
             "$ref": "#/definitions/targetIndex"
           }
         },
+        "textIndexes": {
+          "title": "Target Text Search Indexes, key: value for weight",
+          "type": "object",
+          "items": {
+            "$ref": "#/definitions/targetTextIndex"
+          }
+        },
         "relations": {
           "title": "Target relations",
           "type": "array",
@@ -269,6 +276,24 @@
     },
     "targetIndex": {
       "type": "string"
+    },
+    "targetTextIndex": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Weighted key name name to be solved in Search criteria",
+          "type": "string"
+        },
+        "value": {
+          "title": "Importance criteria",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "additionalProperties": false
     },
     "targetRelation": {
       "type": "object",


### PR DESCRIPTION
Needed to be able to create Text Indexes for Embedded classes. This will also allow to define different weighted text indexes even if classes uses same embedded object. 
Customer may have an address embedded where City search is important but the Consultant having same embedded address do not wanna have the search in address.